### PR TITLE
Added additional report info and extended UI customisation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,8 +7,7 @@ let package = Package(
     name: "FeedbacksKit",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v14),
-        .macOS(.v13),
+        .iOS(.v14)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Sources/FeedbacksKit/FeedbackForm/FeedbackForm.swift
+++ b/Sources/FeedbacksKit/FeedbackForm/FeedbackForm.swift
@@ -4,14 +4,14 @@ public struct FeedbackForm: View {
 
     public struct Config {
         let title: String
-		let textForegroundColor: Color
+        let textForegroundColor: Color
 
         public init(
-			title: String? = nil,
-			textForegroundColor: Color? = nil
-		) {
-			self.title = title ?? "_send_a_feedback".localized
-			self.textForegroundColor = textForegroundColor ?? .blue
+            title: String? = nil,
+            textForegroundColor: Color? = nil
+        ) {
+            self.title = title ?? "_send_a_feedback".localized
+            self.textForegroundColor = textForegroundColor ?? .blue
         }
     }
 
@@ -40,8 +40,8 @@ public struct FeedbackForm: View {
                     Button {
                         presentationMode.wrappedValue.dismiss()
                     } label: {
-						Text("_cancel".localized)
-							.foregroundColor(config.textForegroundColor)
+                        Text("_cancel".localized)
+                            .foregroundColor(config.textForegroundColor)
                     }
                 }
             }
@@ -57,7 +57,7 @@ public struct FeedbackForm: View {
                 TextField("_email_placeholder".localized, text: $viewModel.email)
                     .keyboardType(.emailAddress)
                     .autocapitalization(.none)
-					.autocorrectionDisabled()
+                    .autocorrectionDisabled()
             } header: {
                 Text("_email_title".localized)
             }
@@ -82,7 +82,7 @@ public struct FeedbackForm: View {
                         .frame(maxWidth: .infinity)
                 } else {
                     Text("_send_feedback".localized)
-						.foregroundColor(viewModel.isSubmitDisabled ? .gray : config.textForegroundColor)
+                        .foregroundColor(viewModel.isSubmitDisabled ? .gray : config.textForegroundColor)
                         .frame(maxWidth: .infinity)
                 }
             }

--- a/Sources/FeedbacksKit/FeedbackForm/FeedbackForm.swift
+++ b/Sources/FeedbacksKit/FeedbackForm/FeedbackForm.swift
@@ -82,7 +82,7 @@ public struct FeedbackForm: View {
                         .frame(maxWidth: .infinity)
                 } else {
                     Text("_send_feedback".localized)
-						.foregroundColor(config.textForegroundColor)
+						.foregroundColor(viewModel.isSubmitDisabled ? .gray : config.textForegroundColor)
                         .frame(maxWidth: .infinity)
                 }
             }

--- a/Sources/FeedbacksKit/FeedbackForm/FeedbackForm.swift
+++ b/Sources/FeedbacksKit/FeedbackForm/FeedbackForm.swift
@@ -47,6 +47,7 @@ public struct FeedbackForm: View {
             }
         }
         .navigationViewStyle(.stack)
+        .accessibilityIdentifier("LeaveFeedbackScreen")
     }
 
     // MARK: Views
@@ -58,12 +59,14 @@ public struct FeedbackForm: View {
                     .keyboardType(.emailAddress)
                     .autocapitalization(.none)
                     .autocorrectionDisabled()
+                    .accessibilityIdentifier("EmailTextField")
             } header: {
                 Text("_email_title".localized)
             }
 
             Section {
                 TextEditor(text: $viewModel.message)
+                    .accessibilityIdentifier("MessageTextEditor")
             } header: {
                 Text("_message_title".localized)
             }
@@ -86,6 +89,7 @@ public struct FeedbackForm: View {
                         .frame(maxWidth: .infinity)
                 }
             }
+            .accessibilityIdentifier("SendFeedbackButton")
             .disabled(viewModel.isSubmitDisabled)
         } footer: {
             footer
@@ -112,6 +116,7 @@ public struct FeedbackForm: View {
             .bold()
             .frame(maxWidth: .infinity)
             .foregroundColor(.green)
+            .accessibilityIdentifier("SendFeedbackSuccessText")
             .onAppear {
                 Task {
                     try? await Task.sleep(nanoseconds: 2_000_000_000)
@@ -128,6 +133,7 @@ public struct FeedbackForm: View {
             .bold()
             .frame(maxWidth: .infinity)
             .foregroundColor(.red)
+            .accessibilityIdentifier("SendFeedbackFailureText")
             .onAppear {
                 Task {
                     try? await Task.sleep(nanoseconds: 3_000_000_000)

--- a/Sources/FeedbacksKit/FeedbackForm/FeedbackForm.swift
+++ b/Sources/FeedbacksKit/FeedbackForm/FeedbackForm.swift
@@ -3,24 +3,29 @@ import SwiftUI
 public struct FeedbackForm: View {
 
     public struct Config {
-        let title: String?
+        let title: String
+		let textForegroundColor: Color
 
-        public init(title: String?) {
-            self.title = title
+        public init(
+			title: String? = nil,
+			textForegroundColor: Color? = nil
+		) {
+			self.title = title ?? "_send_a_feedback".localized
+			self.textForegroundColor = textForegroundColor ?? .blue
         }
     }
 
     @Environment(\.presentationMode) private var presentationMode
 
     @StateObject private var viewModel: FeedbackFormViewModel
-    private let config: Config?
+    private let config: Config
 
     public init(
         service: SubmitService,
         config: Config? = nil
     ) {
         self._viewModel = StateObject(wrappedValue: FeedbackFormViewModel(service: service))
-        self.config = config
+        self.config = config ?? Config()
     }
 
     public var body: some View {
@@ -29,13 +34,14 @@ public struct FeedbackForm: View {
                 formFields
                 submitButton
             }
-            .navigationTitle(Text(config?.title ?? "_send_a_feedback".localized))
+            .navigationTitle(Text(config.title))
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button {
                         presentationMode.wrappedValue.dismiss()
                     } label: {
-                        Text("_cancel".localized)
+						Text("_cancel".localized)
+							.foregroundColor(config.textForegroundColor)
                     }
                 }
             }
@@ -51,6 +57,7 @@ public struct FeedbackForm: View {
                 TextField("_email_placeholder".localized, text: $viewModel.email)
                     .keyboardType(.emailAddress)
                     .autocapitalization(.none)
+					.autocorrectionDisabled()
             } header: {
                 Text("_email_title".localized)
             }
@@ -75,6 +82,7 @@ public struct FeedbackForm: View {
                         .frame(maxWidth: .infinity)
                 } else {
                     Text("_send_feedback".localized)
+						.foregroundColor(config.textForegroundColor)
                         .frame(maxWidth: .infinity)
                 }
             }

--- a/Sources/FeedbacksKit/FeedbackForm/FeedbackFormViewModel.swift
+++ b/Sources/FeedbacksKit/FeedbackForm/FeedbackFormViewModel.swift
@@ -11,7 +11,7 @@ class FeedbackFormViewModel: ObservableObject {
         var message: String {
             switch self {
             case .success: return "_feedback_successfully_sent".localized
-            case .failure: return "_oups_error_occured".localized
+            case .failure: return "_oops_error_occurred".localized
             }
         }
     }

--- a/Sources/FeedbacksKit/Model/FeedbackFormData.swift
+++ b/Sources/FeedbacksKit/Model/FeedbackFormData.swift
@@ -4,10 +4,10 @@ public struct FeedbackFormData {
     let email: String
     let message: String
 
-	let deviceName: String
-	let systemNameAndVersion: String
-	let appVersion: String
-	let language: String
+    let deviceModelIdentifier: String
+    let systemNameAndVersion: String
+    let appVersion: String
+    let language: String
 
     public init(
         email: String,
@@ -16,9 +16,9 @@ public struct FeedbackFormData {
         self.email = email
         self.message = message
 
-		deviceName = UIDevice.current.name
-		systemNameAndVersion = "\(UIDevice.current.systemName) \(UIDevice.current.systemVersion)"
-		appVersion = "\(Bundle.main.appVersionLong) (\(Bundle.main.appBuild))"
-		language = Locale.current.localizedString(forIdentifier: Locale.current.identifier) ?? Locale.current.identifier
+        deviceModelIdentifier = UIDevice.modelIdentifier
+        systemNameAndVersion = "\(UIDevice.current.systemName) \(UIDevice.current.systemVersion)"
+        appVersion = "\(Bundle.main.appVersionLong) (\(Bundle.main.appBuild))"
+        language = Locale.current.localizedString(forIdentifier: Locale.current.identifier) ?? Locale.current.identifier
     }
 }

--- a/Sources/FeedbacksKit/Model/FeedbackFormData.swift
+++ b/Sources/FeedbacksKit/Model/FeedbackFormData.swift
@@ -1,6 +1,13 @@
+import UIKit
+
 public struct FeedbackFormData {
     let email: String
     let message: String
+
+	let deviceName: String
+	let systemNameAndVersion: String
+	let appVersion: String
+	let language: String
 
     public init(
         email: String,
@@ -8,5 +15,10 @@ public struct FeedbackFormData {
     ) {
         self.email = email
         self.message = message
+
+		deviceName = UIDevice.current.name
+		systemNameAndVersion = "\(UIDevice.current.systemName) \(UIDevice.current.systemVersion)"
+		appVersion = "\(Bundle.main.appVersionLong) (\(Bundle.main.appBuild))"
+		language = Locale.current.localizedString(forIdentifier: Locale.current.identifier) ?? Locale.current.identifier
     }
 }

--- a/Sources/FeedbacksKit/Resources/en.lproj/Localizable.strings
+++ b/Sources/FeedbacksKit/Resources/en.lproj/Localizable.strings
@@ -8,4 +8,9 @@
 "_send_feedback" = "Send feedback";
 
 "_feedback_successfully_sent" = "Feedback successfully sent!";
-"_oups_error_occured" = "Ooups! An error occurred.";
+"_oops_error_occurred" = "Oops! An error occurred.";
+
+"_app_version_heading" = "App version: ";
+"_device_name_heading" = "Device name: ";
+"_sys_name_and_version_heading" = "System: ";
+"_system_locale_heading" = "System Locale: ";

--- a/Sources/FeedbacksKit/Resources/en.lproj/Localizable.strings
+++ b/Sources/FeedbacksKit/Resources/en.lproj/Localizable.strings
@@ -9,8 +9,3 @@
 
 "_feedback_successfully_sent" = "Feedback successfully sent!";
 "_oops_error_occurred" = "Oops! An error occurred.";
-
-"_app_version_heading" = "App version: ";
-"_device_name_heading" = "Device name: ";
-"_sys_name_and_version_heading" = "System: ";
-"_system_locale_heading" = "System Locale: ";

--- a/Sources/FeedbacksKit/Resources/fr.lproj/Localizable.strings
+++ b/Sources/FeedbacksKit/Resources/fr.lproj/Localizable.strings
@@ -9,8 +9,3 @@
 
 "_feedback_successfully_sent" = "Message envoyé !";
 "_oops_error_occurred" = "Ooups! Il y a eu une erreur...";
-
-"_app_version_heading" = "Version de l'application: ";
-"_device_name_heading" = "Nom de l'appareil: ";
-"_sys_name_and_version_heading" = "Système: ";
-"_system_locale_heading" = "Paramètres régionaux du système: ";

--- a/Sources/FeedbacksKit/Resources/fr.lproj/Localizable.strings
+++ b/Sources/FeedbacksKit/Resources/fr.lproj/Localizable.strings
@@ -8,4 +8,9 @@
 "_send_feedback" = "Envoyer";
 
 "_feedback_successfully_sent" = "Message envoyé !";
-"_oups_error_occured" = "Ooups! Il y a eu une erreur...";
+"_oops_error_occurred" = "Ooups! Il y a eu une erreur...";
+
+"_app_version_heading" = "Version de l'application: ";
+"_device_name_heading" = "Nom de l'appareil: ";
+"_sys_name_and_version_heading" = "Système: ";
+"_system_locale_heading" = "Paramètres régionaux du système: ";

--- a/Sources/FeedbacksKit/Service/NotionSubmitService/NotionSubmitService.swift
+++ b/Sources/FeedbacksKit/Service/NotionSubmitService/NotionSubmitService.swift
@@ -73,7 +73,76 @@ public struct NotionSubmitService: SubmitService {
                             )
                         ]
                     )
-                )
+                ),
+				.init(type: "divider", divider: .init()),
+				.init(
+					object: "block",
+					type: "paragraph",
+					paragraph: .init(
+						richText: [
+							.init(
+								type: "text",
+								text: .init(content: "_app_version_heading".localized),
+								annotations: .init(bold: true)
+							),
+							.init(
+								type: "text",
+								text: .init(content: formData.appVersion)
+							)
+						]
+					)
+				),
+				.init(
+					object: "block",
+					type: "paragraph",
+					paragraph: .init(
+						richText: [
+							.init(
+								type: "text",
+								text: .init(content: "_device_name_heading".localized),
+								annotations: .init(bold: true)
+							),
+							.init(
+								type: "text",
+								text: .init(content: formData.deviceName)
+							)
+						]
+					)
+				),
+				.init(
+					object: "block",
+					type: "paragraph",
+					paragraph: .init(
+						richText: [
+							.init(
+								type: "text",
+								text: .init(content: "_sys_name_and_version_heading".localized),
+								annotations: .init(bold: true)
+							),
+							.init(
+								type: "text",
+								text: .init(content: formData.systemNameAndVersion)
+							)
+						]
+					)
+				),
+				.init(
+					object: "block",
+					type: "paragraph",
+					paragraph: .init(
+						richText: [
+							.init(
+								type: "text",
+								text: .init(content: "_system_locale_heading".localized),
+								annotations: .init(bold: true)
+							),
+							.init(
+								type: "text",
+								text: .init(content: formData.language)
+							)
+						]
+					)
+				)
             ]
         )
     }
@@ -113,9 +182,12 @@ private struct NotionBody: Codable {
     }
 
     struct Child: Codable {
-        let object: String
+        var object: String?
         let type: String
-        let paragraph: Paragraph
+        var paragraph: Paragraph?
+		var divider: Divider?
+
+		struct Divider: Codable {}
 
         struct Paragraph: Codable {
             let richText: [RichText]
@@ -123,6 +195,15 @@ private struct NotionBody: Codable {
             struct RichText: Codable {
                 let type: String
                 let text: Text
+				struct Annotations: Codable {
+					var bold = false
+					var italic = false
+					var strikethrough = false
+					var underline = false
+					var code = false
+					var color = "default"
+				}
+				var annotations: Annotations?
 
                 struct Text: Codable {
                     let content: String

--- a/Sources/FeedbacksKit/Service/NotionSubmitService/NotionSubmitService.swift
+++ b/Sources/FeedbacksKit/Service/NotionSubmitService/NotionSubmitService.swift
@@ -74,75 +74,75 @@ public struct NotionSubmitService: SubmitService {
                         ]
                     )
                 ),
-				.init(type: "divider", divider: .init()),
-				.init(
-					object: "block",
-					type: "paragraph",
-					paragraph: .init(
-						richText: [
-							.init(
-								type: "text",
-								text: .init(content: "App version: "),
-								annotations: .init(bold: true)
-							),
-							.init(
-								type: "text",
-								text: .init(content: formData.appVersion)
-							)
-						]
-					)
-				),
-				.init(
-					object: "block",
-					type: "paragraph",
-					paragraph: .init(
-						richText: [
-							.init(
-								type: "text",
-								text: .init(content: "Device name: "),
-								annotations: .init(bold: true)
-							),
-							.init(
-								type: "text",
-								text: .init(content: formData.deviceName)
-							)
-						]
-					)
-				),
-				.init(
-					object: "block",
-					type: "paragraph",
-					paragraph: .init(
-						richText: [
-							.init(
-								type: "text",
-								text: .init(content: "System: "),
-								annotations: .init(bold: true)
-							),
-							.init(
-								type: "text",
-								text: .init(content: formData.systemNameAndVersion)
-							)
-						]
-					)
-				),
-				.init(
-					object: "block",
-					type: "paragraph",
-					paragraph: .init(
-						richText: [
-							.init(
-								type: "text",
-								text: .init(content: "System Locale: "),
-								annotations: .init(bold: true)
-							),
-							.init(
-								type: "text",
-								text: .init(content: formData.language)
-							)
-						]
-					)
-				)
+                .init(type: "divider", divider: .init()),
+                .init(
+                    object: "block",
+                    type: "paragraph",
+                    paragraph: .init(
+                        richText: [
+                            .init(
+                                type: "text",
+                                text: .init(content: "App version: "),
+                                annotations: .init(bold: true)
+                            ),
+                            .init(
+                                type: "text",
+                                text: .init(content: formData.appVersion)
+                            )
+                        ]
+                    )
+                ),
+                .init(
+                    object: "block",
+                    type: "paragraph",
+                    paragraph: .init(
+                        richText: [
+                            .init(
+                                type: "text",
+                                text: .init(content: "Device model identifier: "),
+                                annotations: .init(bold: true)
+                            ),
+                            .init(
+                                type: "text",
+                                text: .init(content: formData.deviceModelIdentifier)
+                            )
+                        ]
+                    )
+                ),
+                .init(
+                    object: "block",
+                    type: "paragraph",
+                    paragraph: .init(
+                        richText: [
+                            .init(
+                                type: "text",
+                                text: .init(content: "System: "),
+                                annotations: .init(bold: true)
+                            ),
+                            .init(
+                                type: "text",
+                                text: .init(content: formData.systemNameAndVersion)
+                            )
+                        ]
+                    )
+                ),
+                .init(
+                    object: "block",
+                    type: "paragraph",
+                    paragraph: .init(
+                        richText: [
+                            .init(
+                                type: "text",
+                                text: .init(content: "System Locale: "),
+                                annotations: .init(bold: true)
+                            ),
+                            .init(
+                                type: "text",
+                                text: .init(content: formData.language)
+                            )
+                        ]
+                    )
+                )
             ]
         )
     }
@@ -185,9 +185,9 @@ private struct NotionBody: Codable {
         var object: String?
         let type: String
         var paragraph: Paragraph?
-		var divider: Divider?
-
-		struct Divider: Codable {}
+        var divider: Divider?
+        
+        struct Divider: Codable {}
 
         struct Paragraph: Codable {
             let richText: [RichText]
@@ -195,15 +195,15 @@ private struct NotionBody: Codable {
             struct RichText: Codable {
                 let type: String
                 let text: Text
-				struct Annotations: Codable {
-					var bold = false
-					var italic = false
-					var strikethrough = false
-					var underline = false
-					var code = false
-					var color = "default"
-				}
-				var annotations: Annotations?
+                struct Annotations: Codable {
+                    var bold = false
+                    var italic = false
+                    var strikethrough = false
+                    var underline = false
+                    var code = false
+                    var color = "default"
+                }
+                var annotations: Annotations?
 
                 struct Text: Codable {
                     let content: String

--- a/Sources/FeedbacksKit/Service/NotionSubmitService/NotionSubmitService.swift
+++ b/Sources/FeedbacksKit/Service/NotionSubmitService/NotionSubmitService.swift
@@ -82,7 +82,7 @@ public struct NotionSubmitService: SubmitService {
 						richText: [
 							.init(
 								type: "text",
-								text: .init(content: "_app_version_heading".localized),
+								text: .init(content: "App version: "),
 								annotations: .init(bold: true)
 							),
 							.init(
@@ -99,7 +99,7 @@ public struct NotionSubmitService: SubmitService {
 						richText: [
 							.init(
 								type: "text",
-								text: .init(content: "_device_name_heading".localized),
+								text: .init(content: "Device name: "),
 								annotations: .init(bold: true)
 							),
 							.init(
@@ -116,7 +116,7 @@ public struct NotionSubmitService: SubmitService {
 						richText: [
 							.init(
 								type: "text",
-								text: .init(content: "_sys_name_and_version_heading".localized),
+								text: .init(content: "System: "),
 								annotations: .init(bold: true)
 							),
 							.init(
@@ -133,7 +133,7 @@ public struct NotionSubmitService: SubmitService {
 						richText: [
 							.init(
 								type: "text",
-								text: .init(content: "_system_locale_heading".localized),
+								text: .init(content: "System Locale: "),
 								annotations: .init(bold: true)
 							),
 							.init(

--- a/Sources/FeedbacksKit/Utils/Bundle+VersionInfo.swift
+++ b/Sources/FeedbacksKit/Utils/Bundle+VersionInfo.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 extension Bundle {
-	var appBuild: String { getInfo("CFBundleVersion") }
-	var appVersionLong: String { getInfo("CFBundleShortVersionString") }
-	var appVersionShort: String { getInfo("CFBundleShortVersion") }
+    var appBuild: String { getInfo("CFBundleVersion") }
+    var appVersionLong: String { getInfo("CFBundleShortVersionString") }
+    var appVersionShort: String { getInfo("CFBundleShortVersion") }
 
-	private func getInfo(_ string: String) -> String {
-		infoDictionary?[string] as? String ?? "⚠️"
-	}
+    private func getInfo(_ string: String) -> String {
+        infoDictionary?[string] as? String ?? "⚠️"
+    }
 }

--- a/Sources/FeedbacksKit/Utils/Bundle+VersionInfo.swift
+++ b/Sources/FeedbacksKit/Utils/Bundle+VersionInfo.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension Bundle {
+	var appBuild: String { getInfo("CFBundleVersion") }
+	var appVersionLong: String { getInfo("CFBundleShortVersionString") }
+	var appVersionShort: String { getInfo("CFBundleShortVersion") }
+
+	private func getInfo(_ string: String) -> String {
+		infoDictionary?[string] as? String ?? "⚠️"
+	}
+}

--- a/Sources/FeedbacksKit/Utils/UIDevice+ModelInfo.swift
+++ b/Sources/FeedbacksKit/Utils/UIDevice+ModelInfo.swift
@@ -1,0 +1,22 @@
+import UIKit
+
+extension UIDevice {
+
+    /// The device model identifier e.g. "iPhone14,5" (iPhone 13) or "Simulator"
+    static var modelIdentifier: String {
+        var systemInfo = utsname()
+        uname(&systemInfo)
+        let machineMirror = Mirror(reflecting: systemInfo.machine)
+        let identifier = machineMirror.children.reduce("") { identifier, element in
+            guard let value = element.value as? Int8, value != 0 else { return identifier }
+            return identifier + String(UnicodeScalar(UInt8(value)))
+        }
+
+        switch identifier {
+        case "i386", "x86_64":
+            return "Simulator"
+        default:
+            return identifier
+        }
+    }
+}

--- a/Sources/FeedbacksKit/Utils/View+hideKeyboard.swift
+++ b/Sources/FeedbacksKit/Utils/View+hideKeyboard.swift
@@ -7,3 +7,7 @@ extension View {
     }
 }
 #endif
+
+
+
+


### PR DESCRIPTION
Added additional report information for Notion integration
* Added App version, device name, system name and version & user's device locale
* Added support for use of dividers to better separate information

Extended UI customisation
* Added option to customise the text foreground colour for the cancel and submit buttons
* Submit text color is now gray when the button is disabled

Localisations
* Corrected typo in english "oops" error text